### PR TITLE
評価詳細の★と説明の位置を入れ替える

### DIFF
--- a/src/_includes/rating-0.njk
+++ b/src/_includes/rating-0.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">0</span>
+</div>

--- a/src/_includes/rating-0_5.njk
+++ b/src/_includes/rating-0_5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">0.5</span>
+</div>

--- a/src/_includes/rating-1.njk
+++ b/src/_includes/rating-1.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">1</span>
+</div>

--- a/src/_includes/rating-1_5.njk
+++ b/src/_includes/rating-1_5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">1.5</span>
+</div>

--- a/src/_includes/rating-2.njk
+++ b/src/_includes/rating-2.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">2</span>
+</div>

--- a/src/_includes/rating-2_5.njk
+++ b/src/_includes/rating-2_5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">2.5</span>
+</div>

--- a/src/_includes/rating-3.njk
+++ b/src/_includes/rating-3.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">3</span>
+</div>

--- a/src/_includes/rating-3_5.njk
+++ b/src/_includes/rating-3_5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">3.5</span>
+</div>

--- a/src/_includes/rating-4.njk
+++ b/src/_includes/rating-4.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">4</span>
+</div>

--- a/src/_includes/rating-4_5.njk
+++ b/src/_includes/rating-4_5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">4.5</span>
+</div>

--- a/src/_includes/rating-5.njk
+++ b/src/_includes/rating-5.njk
@@ -1,0 +1,11 @@
+<div class="Evaluation__starRating">
+  <span class="Evaluation__stars" aria-hidden="true">
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+    <img src="/ppe/image/star-black.svg" alt="黒い星" />
+  </span>
+  <span class="VisuallyHidden">5段階中</span>
+  <span class="Evaluation__starRatingValue">5</span>
+</div>

--- a/src/ppe/face-shield/01.njk
+++ b/src/ppe/face-shield/01.njk
@@ -153,64 +153,64 @@ permalink: ppe/face-shield/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/face-shield/01.njk
+++ b/src/ppe/face-shield/01.njk
@@ -160,136 +160,56 @@ permalink: ppe/face-shield/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">３</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/face-shield/02.njk
+++ b/src/ppe/face-shield/02.njk
@@ -160,136 +160,56 @@ permalink: ppe/face-shield/02.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3.5</span>
-              </div>
+              {% include "rating-3_5.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/face-shield/02.njk
+++ b/src/ppe/face-shield/02.njk
@@ -153,64 +153,64 @@ permalink: ppe/face-shield/02.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3_5.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-3_5.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/face-shield/03.njk
+++ b/src/ppe/face-shield/03.njk
@@ -160,136 +160,56 @@ permalink: ppe/face-shield/03.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-half.svg" alt="左半分が黒、右半分が白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4.5</span>
-              </div>
+              {% include "rating-4_5.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/face-shield/03.njk
+++ b/src/ppe/face-shield/03.njk
@@ -153,64 +153,64 @@ permalink: ppe/face-shield/03.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4_5.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-4_5.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/gown/01.njk
+++ b/src/ppe/gown/01.njk
@@ -151,64 +151,64 @@ permalink: ppe/gown/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-1.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/gown/01.njk
+++ b/src/ppe/gown/01.njk
@@ -158,136 +158,56 @@ permalink: ppe/gown/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">1</span>
-              </div>
+              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/gown/02.njk
+++ b/src/ppe/gown/02.njk
@@ -141,136 +141,56 @@ permalink: ppe/gown/02.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">1</span>
-              </div>
+              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/gown/02.njk
+++ b/src/ppe/gown/02.njk
@@ -134,64 +134,64 @@ permalink: ppe/gown/02.html
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
               <b>非準拠</b>
-              <small style="display: inline-block">防水性の高い素材を用いた雨ガッパ等は準拠相当</small>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <small style="display: inline-block">防水性の高い素材を用いた雨ガッパ等は準拠相当</small>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-1.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/gown/03.njk
+++ b/src/ppe/gown/03.njk
@@ -131,64 +131,64 @@ permalink: ppe/gown/03.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-5.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-1.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/gown/03.njk
+++ b/src/ppe/gown/03.njk
@@ -138,136 +138,56 @@ permalink: ppe/gown/03.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">5</span>
-              </div>
+              {% include "rating-5.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">1</span>
-              </div>
+              {% include "rating-1.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/mask/01.njk
+++ b/src/ppe/mask/01.njk
@@ -169,136 +169,56 @@ permalink: ppe/mask/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">３</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/mask/01.njk
+++ b/src/ppe/mask/01.njk
@@ -162,64 +162,64 @@ permalink: ppe/mask/01.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/mask/02.njk
+++ b/src/ppe/mask/02.njk
@@ -158,64 +158,64 @@ permalink: ppe/mask/02.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">規格等</dt>
             <dd class="EvaluationsList__content">
-              <b>非準拠</b>
               <span class="EvaluationsList__description">JIS規格の準拠に相当すると思われるか</span>
+              <b>非準拠</b>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
+              {% include "rating-2.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
+              {% include "rating-3.njk" %}
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
+              {% include "rating-4.njk" %}
             </dd>
           </div>
         </dl>

--- a/src/ppe/mask/02.njk
+++ b/src/ppe/mask/02.njk
@@ -165,136 +165,56 @@ permalink: ppe/mask/02.html
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">飛沫防護性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">正面および上部等からの飛沫の進入を十分に防げるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">運動フィット性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">小走りや振り向きなどの運動でズレないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">快適性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">息苦しさや接触などの不快感が防止されているか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">使用耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">使用中に想定される衝突や引っかきに耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">消毒耐久性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">2</span>
-              </div>
+              {% include "rating-2.njk" %}
               <span class="EvaluationsList__description">アルコールや次亜塩素酸ナトリウムによる除染・消毒に耐えるか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">作製容易性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">作製に特別な練習を必要としないか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">省コスト性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">3</span>
-              </div>
+              {% include "rating-3.njk" %}
               <span class="EvaluationsList__description">材料の価格や入手などのハードルは低いか</span>
             </dd>
           </div>
           <div class="EvaluationsList__item">
             <dt class="EvaluationsList__head">再利用性</dt>
             <dd class="EvaluationsList__content">
-              <div class="Evaluation__starRating">
-                <span class="Evaluation__stars" aria-hidden="true">
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img src="/ppe/image/star-black.svg" alt="黒い星" />
-                  <img class="Evaluation__star -white" src="/ppe/image/star-white.svg" alt="白い星" />
-                </span>
-                <span class="VisuallyHidden">5段階中</span>
-                <span class="Evaluation__starRatingValue">4</span>
-              </div>
+              {% include "rating-4.njk" %}
               <span class="EvaluationsList__description">適切な除染・消毒による再度利用は可能か</span>
             </dd>
           </div>

--- a/src/ppe/style/Block/EvaluationsList.css
+++ b/src/ppe/style/Block/EvaluationsList.css
@@ -27,7 +27,6 @@
 .Evaluation__starRating {
   display: flex;
   align-items: center;
-  margin-top: 8px;
 }
 
 .Evaluation__stars {
@@ -43,6 +42,11 @@
 
 .Evaluation__starRatingValue {
   margin-left: 8px;
+}
+
+.EvaluationsList__description {
+  display: block;
+  margin-bottom: 8px;
 }
 
 @media (max-width: 427px) {
@@ -85,7 +89,6 @@
   }
 
   .EvaluationsList__description {
-    display: block;
     font-size: 0.75rem;
   }
 }

--- a/src/ppe/style/Block/EvaluationsList.css
+++ b/src/ppe/style/Block/EvaluationsList.css
@@ -27,7 +27,7 @@
 .Evaluation__starRating {
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
+  margin-top: 8px;
 }
 
 .Evaluation__stars {


### PR DESCRIPTION
評価詳細の★と説明の位置を、説明が先で星を次の行に入れ替えました。

| Wide_Before | Wide_After |
| :---: | :---: |
| ![スクリーンショット 2020-04-25 23 14 33](https://user-images.githubusercontent.com/710216/80282108-97109f00-874a-11ea-830e-958fc91eb484.png) | ![スクリーンショット 2020-04-25 23 14 14](https://user-images.githubusercontent.com/710216/80282112-9b3cbc80-874a-11ea-8e90-a44107a70ef8.png) |

| Tight_Before | Tight_After |
| :---: | :---: |
| ![スクリーンショット 2020-04-25 23 14 51](https://user-images.githubusercontent.com/710216/80282123-a98ad880-874a-11ea-804d-b1598a6383d6.png) | ![スクリーンショット 2020-04-25 23 13 57](https://user-images.githubusercontent.com/710216/80282139-b8718b00-874a-11ea-96d6-7f45df5bceeb.png) |


合わせて、`. Evaluation__starRating` を `_includes/` に切り出しました。
確認お願いいたします。