### PR TITLE
ファイルの保存日を使ったキャッシュバスターをOGP画像に追加する

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,6 +16,11 @@ module.exports = function (eleventyConfig) {
     return dayjs(v).format("YYYY-MM-DDTHH:mmZ");
   });
 
+  // filter
+  eleventyConfig.addNunjucksFilter("cacheBuster", (v) => {
+    return `?${v.getTime()}`
+  });
+
   // browser-sync option
   eleventyConfig.setBrowserSyncConfig({
     startPath: "/ppe/"

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,9 +16,9 @@ module.exports = function (eleventyConfig) {
     return dayjs(v).format("YYYY-MM-DDTHH:mmZ");
   });
 
-  // filter
-  eleventyConfig.addNunjucksFilter("cacheBuster", (v) => {
-    return `?${v.getTime()}`
+  // Shortcode
+  eleventyConfig.addShortcode("cacheBuster", () => {
+    return `?${dayjs().format("YYYYMMDDHHmm")}`
   });
 
   // browser-sync option

--- a/src/ppe/face-shield/01.njk
+++ b/src/ppe/face-shield/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/01.njk
+++ b/src/ppe/face-shield/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/02.njk
+++ b/src/ppe/face-shield/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/02.njk
+++ b/src/ppe/face-shield/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/03.njk
+++ b/src/ppe/face-shield/03.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/03.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/03.njk
+++ b/src/ppe/face-shield/03.njk
@@ -26,8 +26,8 @@ permalink: ppe/face-shield/03.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/index.njk
+++ b/src/ppe/face-shield/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/face-shield/index.njk
+++ b/src/ppe/face-shield/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/01.njk
+++ b/src/ppe/gown/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/01.njk
+++ b/src/ppe/gown/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/02.njk
+++ b/src/ppe/gown/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/02.njk
+++ b/src/ppe/gown/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/03.njk
+++ b/src/ppe/gown/03.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/03.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/03.njk
+++ b/src/ppe/gown/03.njk
@@ -26,8 +26,8 @@ permalink: ppe/gown/03.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/index.njk
+++ b/src/ppe/gown/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/gown/index.njk
+++ b/src/ppe/gown/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/index.njk
+++ b/src/ppe/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/index.njk
+++ b/src/ppe/index.njk
@@ -2,8 +2,8 @@
 date: Last Modified
 base: https://covid-19-act.jp/ppe/
 public_url: https://covid-19-act.jp/ppe/
-og_image: http://covid-19-act.jp/ppe/image/OGP.png?20200427v2
-og_image_secure: https://covid-19-act.jp/ppe/image/OGP.png?20200427v2
+og_image: http://covid-19-act.jp/ppe/image/OGP.png
+og_image_secure: https://covid-19-act.jp/ppe/image/OGP.png
 og_image_width: 1200
 og_image_height: 630
 og_image_alt: Act Against COVID-19 医療用個人防護具の代替品 性能評価と作り方
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/01.njk
+++ b/src/ppe/mask/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/mask/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/01.njk
+++ b/src/ppe/mask/01.njk
@@ -26,8 +26,8 @@ permalink: ppe/mask/01.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/02.njk
+++ b/src/ppe/mask/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/mask/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/02.njk
+++ b/src/ppe/mask/02.njk
@@ -26,8 +26,8 @@ permalink: ppe/mask/02.html
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/index.njk
+++ b/src/ppe/mask/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
+    <meta property="og:image" content="{{ og_image }}{% cacheBuster %}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{% cacheBuster %}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">

--- a/src/ppe/mask/index.njk
+++ b/src/ppe/mask/index.njk
@@ -25,8 +25,8 @@ permalink:
     <meta property="og:description" content="{{ og_description }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ public_url }}">
-    <meta property="og:image" content="{{ og_image }}">
-    <meta property="og:image:secure_url" content="{{ og_image_secure }}">
+    <meta property="og:image" content="{{ og_image }}{{ page.date | cacheBuster }}">
+    <meta property="og:image:secure_url" content="{{ og_image_secure }}{{ page.date | cacheBuster }}">
     <meta property="og:image:width" content="{{ og_image_width }}">
     <meta property="og:image:height" content="{{ og_image_height }}">
     <meta property="og:image:alt" content="{{ og_image_alt }}">


### PR DESCRIPTION
トップページのみに付与されていたOGPのキャッシュバスターを全ページに追加しました。

キャッシュバスターのシードとして njk ファイルの保存日を `.getTime()` して数字文字列にして返す Nunjucks Filter 'cacheBuster' を追加しています。

確認お願いします。