### PR TITLE
後援に「一般社団法人日本病院会」と「一般社団法人東京都病院協会」を追加する

### DIFF
--- a/src/ppe/index.njk
+++ b/src/ppe/index.njk
@@ -152,6 +152,8 @@ permalink:
           <ul class="SkeltonList">
             <li>公益社団法人全日本病院協会</li>
             <li>一般社団法人日本医療法人協会</li>
+            <li>一般社団法人日本病院会</li>
+            <li>一般社団法人東京都病院協会</li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
しました。